### PR TITLE
Fixed PoeHud Popup Error

### DIFF
--- a/StashieCore.cs
+++ b/StashieCore.cs
@@ -1089,34 +1089,37 @@ namespace Stashie
                     continue;
                 }
 
-                var stashPanel = _ingameState.ServerData.StashPanel;
-                if (!GameController.InGame || !stashPanel.IsVisible)
+                if (_ingameState.ServerData.StashPanel != null)
                 {
-                    Thread.Sleep(500);
-                    continue;
+                        var stashPanel = _ingameState.ServerData.StashPanel;
+                        if (!GameController.InGame || !stashPanel.IsVisible)
+                        {
+                            Thread.Sleep(500);
+                            continue;
+                        }
+
+                        var cachedNames = Settings.AllStashNames;
+                        var realNames = stashPanel.AllStashNames;
+
+                        if (realNames.Count + 1 != cachedNames.Count)
+                        {
+                            UpdateStashNames(realNames);
+                            continue;
+                        }
+
+                        for (var index = 0; index < realNames.Count; ++index)
+                        {
+                            var cachedName = cachedNames[index + 1];
+                            if (cachedName.Equals(realNames[index]))
+                            {
+                                continue;
+                            }
+
+                            UpdateStashNames(realNames);
+                            break;
+                        }
                 }
-
-                var cachedNames = Settings.AllStashNames;
-                var realNames = stashPanel.AllStashNames;
-
-                if (realNames.Count + 1 != cachedNames.Count)
-                {
-                    UpdateStashNames(realNames);
-                    continue;
-                }
-
-                for (var index = 0; index < realNames.Count; ++index)
-                {
-                    var cachedName = cachedNames[index + 1];
-                    if (cachedName.Equals(realNames[index]))
-                    {
-                        continue;
-                    }
-
-                    UpdateStashNames(realNames);
-                    break;
-                }
-
+                
                 Thread.Sleep(300);
             }
 


### PR DESCRIPTION
Program exited with message:
 System.NullReferenceException: Object reference not set to an instance of an object.
   at Stashie.StashieCore.StashTabNamesUpdater_Thread() in C:\Users\*\Documents\Stashie\StashieCore.cs:line 1088
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()