### PR TITLE
Added splinter exclusion to currency option

### DIFF
--- a/StashieCore.cs
+++ b/StashieCore.cs
@@ -158,7 +158,7 @@ namespace Stashie
                 "/////////////////////////////////////////////////////////////\r\n" +
                 "\r\n" +
                 "//Default Tabs\r\n" +
-                "Currency:\t\t\tClassName=StackableCurrency,path!^Essence,path!^Fossil\t\t\t\t:Default Tabs\r\n" +
+                "Currency:\t\t\tClassName=StackableCurrency,path!^Essence,path!^Fossil,BaseName!^Splinter of\t\t\t\t:Default Tabs\r\n" +
                 "Divination Cards:\tClassName=DivinationCard\t\t\t\t\t\t\t\t\t\t:Default Tabs\r\n" +
                 "Essences:\t\t\tBaseName^Essence,ClassName=StackableCurrency\t\t\t\t\t:Default Tabs\r\n" +
                 "Splinters:\t\t\tBaseName^Splinter of,ClassName=StackableCurrency\t\t\t\t:Default Tabs\r\n" +


### PR DESCRIPTION
Broke it in last commit when i rearranged the order of options.