### PR TITLE
Add Reload config button

### DIFF
--- a/FilterParser.cs
+++ b/FilterParser.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using ExileCore;
+using SharpDX;
 
 namespace Stashie
 {
@@ -60,13 +61,13 @@ namespace Stashie
 
         private static readonly string[] Operations =
         {
-            OPERATION_NONEQUALITY, 
-            OPERATION_LESSEQUAL, 
-            OPERATION_BIGGERQUAL, 
-            OPERATION_NOTCONTAINS, 
+            OPERATION_NONEQUALITY,
+            OPERATION_LESSEQUAL,
+            OPERATION_BIGGERQUAL,
+            OPERATION_NOTCONTAINS,
             OPERATION_EQUALITY,
-            OPERATION_BIGGER, 
-            OPERATION_LESS, 
+            OPERATION_BIGGER,
+            OPERATION_LESS,
             OPERATION_CONTAINS
         };
 
@@ -138,7 +139,14 @@ namespace Stashie
                     }
                 }
 
-                if (!filterErrorParse) allFilters.Add(newFilter);
+                if (!filterErrorParse)
+                {
+                    allFilters.Add(newFilter);
+                }
+                else
+                {
+                    DebugWindow.LogMsg($"Line: {i + 1}", 5, Color.Red);
+                }
             }
 
             return allFilters;
@@ -157,7 +165,7 @@ namespace Stashie
 
             if (command.Contains(PARAMETER_ISCORRUPTED))
             {
-                var corruptedCommand = new CorruptedItemFilter { BCorrupted = command[0] != SYMBOL_NOT };
+                var corruptedCommand = new CorruptedItemFilter {BCorrupted = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(corruptedCommand);
                 return true;
             }
@@ -178,58 +186,53 @@ namespace Stashie
 
             if (command.Contains(PARAMETER_ISCRUSADER))
             {
-                var crusaderCommand = new CrusaderItemFilter { isCrusader = command[0] != SYMBOL_NOT };
+                var crusaderCommand = new CrusaderItemFilter {isCrusader = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(crusaderCommand);
                 return true;
             }
 
             if (command.Contains(PARAMETER_ISHUNTER))
             {
-                var hunterCommand = new HunterItemFilter { isHunter = command[0] != SYMBOL_NOT };
+                var hunterCommand = new HunterItemFilter {isHunter = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(hunterCommand);
                 return true;
             }
 
             if (command.Contains(PARAMETER_ISREDEEMER))
             {
-                var redeemerCommand = new RedeemerItemFilter { isRedeemer = command[0] != SYMBOL_NOT };
+                var redeemerCommand = new RedeemerItemFilter {isRedeemer = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(redeemerCommand);
                 return true;
             }
 
             if (command.Contains(PARAMETER_ISWARLORD))
             {
-                var warordCommand = new WarlordItemFilter { isWarlord = command[0] != SYMBOL_NOT };
+                var warordCommand = new WarlordItemFilter {isWarlord = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(warordCommand);
                 return true;
             }
 
             if (command.Contains(PARAMETER_ISINFLUENCED))
             {
-                var influencedCommand = new AnyInfluenceItemFilter { isInfluenced = command[0] != SYMBOL_NOT };
+                var influencedCommand = new AnyInfluenceItemFilter {isInfluenced = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(influencedCommand);
                 return true;
             }
 
             if (command.Contains(PARAMETER_ISBLIGHTEDMAP))
             {
-                var blightedMapCommand = new BlightedMapFilter { isBlightMap = command[0] != SYMBOL_NOT };
+                var blightedMapCommand = new BlightedMapFilter {isBlightMap = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(blightedMapCommand);
                 return true;
             }
+
             if (command.Contains(PARAMETER_ISELDERGUARDIANMAP))
             {
-                var elderGuardianMapCommand = new ElderGuardianMapFilter { isElderGuardianMap = command[0] != SYMBOL_NOT };
+                var elderGuardianMapCommand = new ElderGuardianMapFilter
+                    {isElderGuardianMap = command[0] != SYMBOL_NOT};
                 newFilter.Filters.Add(elderGuardianMapCommand);
                 return true;
             }
-            /*
-            if (command.Contains(PARAMETER_ISSYNTHESISED))
-            {
-                var synthesisedCommand = new SynthesisedItemFilter { IsSynthesised = command[0] != SYMBOL_NOT };
-                newFilter.Filters.Add(synthesisedCommand);
-                return true;
-            }*/
 
             string parameter;
             string operation;
@@ -237,7 +240,7 @@ namespace Stashie
 
             if (!ParseCommand(command, out parameter, out operation, out value))
             {
-                DebugWindow.LogMsg("Filter parser: Can't parse filter part: " + command, 5);
+                DebugWindow.LogMsg($"Unknown operation: {command}", 5, Color.Red);
                 return false;
             }
 
@@ -260,10 +263,6 @@ namespace Stashie
                 case PARAMETER_DESCRIPTION:
                     stringComp.StringParameter = data => data.Description;
                     break;
-                    /*
-                case PARAMETER_CLUSTERJEWELBASE:
-                    stringComp.StringParameter = data => data.ClusterJewelBase;
-                    break;*/
                 case PARAMETER_RARITY:
                     stringComp.StringParameter = data => data.Rarity.ToString();
                     break;
@@ -286,7 +285,7 @@ namespace Stashie
                     stringComp.IntParameter = data => data.NumberOfSockets;
                     stringComp.CompareInt = int.Parse(value);
                     stringComp.StringParameter = data => data.NumberOfSockets.ToString();
-                    break;   
+                    break;
                 case PARAMETER_LARGEST_LINK_SIZE:
                     stringComp.IntParameter = data => data.LargestLinkSize;
                     stringComp.CompareInt = int.Parse(value);
@@ -302,12 +301,6 @@ namespace Stashie
                     stringComp.CompareInt = int.Parse(value);
                     stringComp.StringParameter = data => data.Fractured.ToString();
                     break;
-                    /*
-                case PARAMTER_CLUSTERJEWELPASSIVES:
-                    stringComp.IntParameter = data => data.ClusterJewelpassives;
-                    stringComp.CompareInt = int.Parse(value);
-                    stringComp.StringParameter = data => data.ClusterJewelpassives.ToString();
-                    break;*/
 
 
                 default:

--- a/Stashie.cs
+++ b/Stashie.cs
@@ -297,6 +297,7 @@ namespace Stashie
             if (ImGui.Button("Reload config"))
             {
                 LoadCustomFilters();
+                GenerateMenu();
                 DebugWindow.LogMsg("Reloaded Stashie config", 2, Color.LimeGreen);
             }
         }
@@ -428,42 +429,6 @@ namespace Stashie
             _settingsListNodes.Add(Settings.CurrencyStashTab);
         }
 
-        private void LoadIgnoredCells()
-        {
-            const string fileName = @"/IgnoredCells.json";
-            var filePath = DirectoryFullName + fileName;
-
-            if (File.Exists(filePath))
-            {
-                var json = File.ReadAllText(filePath);
-
-                try
-                {
-                    Settings.IgnoredCells = JsonConvert.DeserializeObject<int[,]>(json);
-                    var ignoredHeight = Settings.IgnoredCells.GetLength(0);
-                    var ignoredWidth = Settings.IgnoredCells.GetLength(1);
-
-                    if (ignoredHeight != 5 || ignoredWidth != 12)
-                        LogError("Stashie: Wrong IgnoredCells size! Should be 12x5. Resetting to default..", 5);
-                    else
-                        return;
-                }
-                catch (Exception ex)
-                {
-                    LogError(
-                        "Stashie: Can't decode IgnoredCells settings in " + fileName +
-                        ". Resetting to default. Error: " + ex.Message,
-                        5);
-                }
-            }
-
-            var defaultSettings = JsonConvert.SerializeObject(Settings.IgnoredCells);
-            defaultSettings = defaultSettings.Replace("[[", "[\n[");
-            defaultSettings = defaultSettings.Replace("],[", "],\n[");
-            defaultSettings = defaultSettings.Replace("]]", "]\n]");
-            File.WriteAllText(filePath, defaultSettings);
-        }
-
         public override void Render()
         {
             if (_coroutineWorker != null && _coroutineWorker.IsDone)
@@ -549,20 +514,6 @@ namespace Stashie
                         _dropItems.Add(result);
                 }
             }
-        }
-
-        private void WriteInventoryNames()
-        {
-            var path = $"{DirectoryFullName}\\InventoryDebugList.txt";
-            var sb = new StringBuilder();
-            foreach (var inventoryItem in _dropItems)
-            {
-                sb.AppendLine(inventoryItem.ItemData.BaseName);
-                sb.AppendLine(inventoryItem.ItemData.ClassName);
-                sb.AppendLine(inventoryItem.ItemData.Path.ToString());
-            }
-
-            File.WriteAllText(path, sb.ToString());
         }
 
         private bool CheckIgnoreCells(NormalInventoryItem inventItem)

--- a/Stashie.cs
+++ b/Stashie.cs
@@ -22,31 +22,29 @@ namespace Stashie
 {
     public class StashieCore : BaseSettingsPlugin<StashieSettings>
     {
-        private const string stashTabsNameChecker = "Stash Tabs Name Checker";
-        private const string FILTERS_CONFIG_FILE = "FiltersConfig.txt";
-        private const int WHILE_DELAY = 5;
-        private const int INPUT_DELAY = 15;
-        private const string coroutineName = "Drop To Stash";
-        private readonly Stopwatch DebugTimer = new Stopwatch();
-        private readonly Stopwatch StackItemTimer = new Stopwatch();
-        private readonly WaitTime wait10ms = new WaitTime(10);
-        private readonly WaitTime wait3ms = new WaitTime(3);
-        private readonly WaitTime wait1ms = new WaitTime(1);
+        private const string StashTabsNameChecker = "Stash Tabs Name Checker";
+        private const string FiltersConfigFile = "FiltersConfig.txt";
+        private const int WhileDelay = 5;
+        private const int InputDelay = 15;
+        private const string CoroutineName = "Drop To Stash";
+        private readonly Stopwatch _debugTimer = new Stopwatch();
+        private readonly Stopwatch _stackItemTimer = new Stopwatch();
+        private readonly WaitTime _wait10Ms = new WaitTime(10);
+        private readonly WaitTime _wait3Ms = new WaitTime(3);
+        private readonly WaitTime _wait1Ms = new WaitTime(1);
         private Vector2 _clickWindowOffset;
         private List<CustomFilter> _customFilters;
         private List<RefillProcessor> _customRefills;
         private List<FilterResult> _dropItems;
         private List<ListIndexNode> _settingsListNodes;
-        private uint coroutineIteration;
-        private Coroutine CoroutineWorker;
-        private Action FilterTabs;
-        private string[] StashTabNamesByIndex;
-        private Coroutine StashTabNamesCoroutine;
-        private Action TestAction;
-        private int visibleStashIndex = -1;
-        private bool playerHasDropdownMenu;
-        private const int MAXSHOWN_SIDEBARSTASHTABS = 32;
-        private int stashcount = 0;
+        private uint _coroutineIteration;
+        private Coroutine _coroutineWorker;
+        private Action _filterTabs;
+        private string[] _stashTabNamesByIndex;
+        private Coroutine _stashTabNamesCoroutine;
+        private int _visibleStashIndex = -1;
+        private const int MaxShownSidebarStashTabs = 32;
+        private int _stashCount;
 
         public StashieCore()
         {
@@ -59,11 +57,13 @@ namespace Stashie
             {
                 if (b)
                 {
-                    if (Core.ParallelRunner.FindByName(stashTabsNameChecker) == null) InitCoroutine();
-                    StashTabNamesCoroutine?.Resume();
+                    if (Core.ParallelRunner.FindByName(StashTabsNameChecker) == null) InitCoroutine();
+                    _stashTabNamesCoroutine?.Resume();
                 }
                 else
-                    StashTabNamesCoroutine?.Pause();
+                {
+                    _stashTabNamesCoroutine?.Pause();
+                }
 
                 SetupOrClose();
             };
@@ -75,8 +75,7 @@ namespace Stashie
             Input.RegisterKey(Keys.ShiftKey);
 
             Settings.DropHotkey.OnValueChanged += () => { Input.RegisterKey(Settings.DropHotkey); };
-            playerHasDropdownMenu = (int) GameController.Game.IngameState.IngameUi.StashElement.TotalStashes > 10;
-            stashcount = (int) GameController.Game.IngameState.IngameUi.StashElement.TotalStashes;
+            _stashCount = (int) GameController.Game.IngameState.IngameUi.StashElement.TotalStashes;
 
             return true;
         }
@@ -85,15 +84,15 @@ namespace Stashie
         {
             //TODO Add lab name with stash
             if (area.IsHideout || area.DisplayName.Contains("Azurite Mine"))
-                StashTabNamesCoroutine?.Resume();
+                _stashTabNamesCoroutine?.Resume();
             else
-                StashTabNamesCoroutine?.Pause();
+                _stashTabNamesCoroutine?.Pause();
         }
 
         private void InitCoroutine()
         {
-            StashTabNamesCoroutine = new Coroutine(StashTabNamesUpdater_Thread(), this, stashTabsNameChecker);
-            Core.ParallelRunner.Run(StashTabNamesCoroutine);
+            _stashTabNamesCoroutine = new Coroutine(StashTabNamesUpdater_Thread(), this, StashTabsNameChecker);
+            Core.ParallelRunner.Run(_stashTabNamesCoroutine);
         }
 
         /// <summary>
@@ -227,6 +226,7 @@ namespace Stashie
 
         public override void DrawSettings()
         {
+            DrawReloadConfigButton();
             DrawIgnoredCellsSettings();
             base.DrawSettings();
 
@@ -238,54 +238,12 @@ namespace Stashie
                 settingsCustomRefillOption.Value.Value = value;
             }
 
-            //if (ImGui.Button("Test"))
-            //{
-            //    TestAction = null;
-            //    var inventory = GameController.Game.IngameState.IngameUi.InventoryPanel[InventoryIndex.PlayerInventory];
-            //    var invItems = inventory?.VisibleInventoryItems;
-
-            //    if (invItems != null)
-            //    {
-            //        var testlist = new List<FilterResult>();
-
-            //        foreach (var invItem in invItems)
-            //        {
-            //            if (invItem.Item == null || invItem.Address == 0 || !invItem.Item.IsValid) continue;
-
-            //            if (CheckIgnoreCells(invItem)) continue;
-
-            //            var baseItemType = GameController.Files.BaseItemTypes.Translate(invItem.Item.Path);
-
-            //            var testItem = new ItemData(invItem, baseItemType);
-            //            var result = CheckFilters(testItem);
-
-            //            if (result != null) testlist.Add(result);
-            //        }
-
-            //        testlist = testlist.OrderByDescending(x => x.StashIndex == visibleStashIndex).ThenBy(x => x.StashIndex).ToList();
-
-            //        TestAction += () =>
-            //        {
-            //            ImGui.Begin("Test stashie drop");
-
-            //            foreach (var result in testlist)
-            //            {
-            //                ImGui.Text(
-            //                    $"{result.Filter.Name} -> {result.ItemData.BaseName} ({result.ItemData.ClassName}) >>> {result.StashIndex} ({StashTabNamesByIndex[result.StashIndex + 1]})");
-            //            }
-
-            //            if (ImGui.Button("Close")) TestAction = null;
-            //            ImGui.End();
-            //        };
-            //    }
-            //}
-
-            FilterTabs?.Invoke();
+            _filterTabs?.Invoke();
         }
 
         private void LoadCustomFilters()
         {
-            var filterPath = Path.Combine(DirectoryFullName, FILTERS_CONFIG_FILE);
+            var filterPath = Path.Combine(DirectoryFullName, FiltersConfigFile);
             var filtersLines = File.ReadAllLines(filterPath);
             var unused = new FilterParser();
             _customFilters = FilterParser.Parse(filtersLines);
@@ -324,10 +282,8 @@ namespace Stashie
                     var inventPosX = item.InventPosX;
                     var inventPosY = item.InventPosY;
                     for (var y = 0; y < itemSizeY; y++)
-                    {
-                        for (var x = 0; x < itemSizeX; x++)
-                            Settings.IgnoredCells[y + inventPosY, x + inventPosX] = 1;
-                    }
+                    for (var x = 0; x < itemSizeX; x++)
+                        Settings.IgnoredCells[y + inventPosY, x + inventPosX] = 1;
                 }
             }
             catch (Exception e)
@@ -336,22 +292,26 @@ namespace Stashie
             }
         }
 
+        private void DrawReloadConfigButton()
+        {
+            if (ImGui.Button("Reload config"))
+            {
+                LoadCustomFilters();
+                DebugWindow.LogMsg("Reloaded Stashie config", 2, Color.LimeGreen);
+            }
+        }
+
         private void DrawIgnoredCellsSettings()
         {
             try
             {
-                if (ImGui.Button("Copy Inventory"))
-                {
-                    SaveIgnoredSLotsFromInventoryTemplate();
-                }
+                if (ImGui.Button("Copy Inventory")) SaveIgnoredSLotsFromInventoryTemplate();
 
                 ImGui.SameLine();
                 ImGui.TextDisabled("(?)");
                 if (ImGui.IsItemHovered())
-                {
                     ImGui.SetTooltip(
                         $"Checked = Item will be ignored{Environment.NewLine}UnChecked = Item will be processed");
-                }
             }
             catch (Exception e)
             {
@@ -360,40 +320,30 @@ namespace Stashie
 
             var numb = 1;
             for (var i = 0; i < 5; i++)
+            for (var j = 0; j < 12; j++)
             {
-                for (var j = 0; j < 12; j++)
-                {
-                    var toggled = Convert.ToBoolean(Settings.IgnoredCells[i, j]);
-                    if (ImGui.Checkbox($"##{numb}IgnoredCells", ref toggled))
-                    {
-                        Settings.IgnoredCells[i, j] ^= 1;
-                    }
+                var toggled = Convert.ToBoolean(Settings.IgnoredCells[i, j]);
+                if (ImGui.Checkbox($"##{numb}IgnoredCells", ref toggled)) Settings.IgnoredCells[i, j] ^= 1;
 
-                    if ((numb - 1) % 12 < 11)
-                    {
-                        ImGui.SameLine();
-                    }
+                if ((numb - 1) % 12 < 11) ImGui.SameLine();
 
-                    numb += 1;
-                }
+                numb += 1;
             }
         }
 
 
         private void GenerateMenu()
         {
-            StashTabNamesByIndex = _renamedAllStashNames.ToArray();
+            _stashTabNamesByIndex = _renamedAllStashNames.ToArray();
 
-            FilterTabs = null;
+            _filterTabs = null;
 
             foreach (var customFilter in _customFilters.GroupBy(x => x.SubmenuName, e => e))
-            {
-                FilterTabs += () =>
+                _filterTabs += () =>
                 {
                     ImGui.TextColored(new Vector4(0f, 1f, 0.022f, 1f), customFilter.Key);
 
                     foreach (var filter in customFilter)
-                    {
                         if (Settings.CustomFilterOptions.TryGetValue(filter.Name, out var indexNode))
                         {
                             var formattableString = $"{filter.Name} => {_renamedAllStashNames[indexNode.Index + 1]}";
@@ -414,50 +364,48 @@ namespace Stashie
                             if (string.IsNullOrWhiteSpace(filterName))
                                 filterName = "Null";
 
-                            if (ImGui.Combo($"##{filterName}", ref item, StashTabNamesByIndex,
-                                StashTabNamesByIndex.Length))
+                            if (ImGui.Combo($"##{filterName}", ref item, _stashTabNamesByIndex,
+                                _stashTabNamesByIndex.Length))
                             {
-                                indexNode.Value = StashTabNamesByIndex[item];
-                                OnSettingsStashNameChanged(indexNode, StashTabNamesByIndex[item]);
+                                indexNode.Value = _stashTabNamesByIndex[item];
+                                OnSettingsStashNameChanged(indexNode, _stashTabNamesByIndex[item]);
                             }
 
                             ImGui.NextColumn();
                             ImGui.Columns(1, "", false);
                             var pop = true;
 
-                            if (ImGui.BeginPopupModal(formattableString, ref pop,
-                                ImGuiWindowFlags.NoResize | ImGuiWindowFlags.AlwaysAutoResize))
+                            if (!ImGui.BeginPopupModal(formattableString, ref pop,
+                                ImGuiWindowFlags.NoResize | ImGuiWindowFlags.AlwaysAutoResize)) continue;
+                            var x = 0;
+
+                            foreach (var name in _renamedAllStashNames)
                             {
-                                var x = 0;
+                                x++;
 
-                                foreach (var name in _renamedAllStashNames)
+                                if (ImGui.Button($"{name}", new System.Numerics.Vector2(100, 20)))
                                 {
-                                    x++;
-
-                                    if (ImGui.Button($"{name}", new System.Numerics.Vector2(100, 20)))
-                                    {
-                                        indexNode.Value = name;
-                                        OnSettingsStashNameChanged(indexNode, name);
-                                        ImGui.CloseCurrentPopup();
-                                    }
-
-                                    if (x % 10 != 0)
-                                        ImGui.SameLine();
+                                    indexNode.Value = name;
+                                    OnSettingsStashNameChanged(indexNode, name);
+                                    ImGui.CloseCurrentPopup();
                                 }
 
-                                ImGui.Spacing();
-                                ImGuiNative.igIndent(350);
-                                if (ImGui.Button("Close", new System.Numerics.Vector2(100, 20)))
-                                    ImGui.CloseCurrentPopup();
-
-                                ImGui.EndPopup();
+                                if (x % 10 != 0)
+                                    ImGui.SameLine();
                             }
+
+                            ImGui.Spacing();
+                            ImGuiNative.igIndent(350);
+                            if (ImGui.Button("Close", new System.Numerics.Vector2(100, 20)))
+                                ImGui.CloseCurrentPopup();
+
+                            ImGui.EndPopup();
                         }
                         else
+                        {
                             indexNode = new ListIndexNode {Value = "Ignore", Index = -1};
-                    }
+                        }
                 };
-            }
         }
 
         private void LoadCustomRefills()
@@ -465,14 +413,9 @@ namespace Stashie
             _customRefills = RefillParser.Parse(DirectoryFullName);
             if (_customRefills.Count == 0) return;
 
-            /* var refillMenu = MenuPlugin.AddChild(PluginSettingsRootMenu, "Refill Currency", Settings.RefillCurrency);
-             MenuPlugin.AddChild(refillMenu, "Currency Tab", Settings.CurrencyStashTab);
-             MenuPlugin.AddChild(refillMenu, "Allow Have More", Settings.AllowHaveMore);*/
             foreach (var refill in _customRefills)
             {
-                RangeNode<int> amountOption;
-
-                if (!Settings.CustomRefillOptions.TryGetValue(refill.MenuName, out amountOption))
+                if (!Settings.CustomRefillOptions.TryGetValue(refill.MenuName, out var amountOption))
                 {
                     amountOption = new RangeNode<int>(15, 0, refill.StackSize);
                     Settings.CustomRefillOptions.Add(refill.MenuName, amountOption);
@@ -480,8 +423,6 @@ namespace Stashie
 
                 amountOption.Max = refill.StackSize;
                 refill.AmountOption = amountOption;
-
-                //  MenuPlugin.AddChild(refillMenu, refill.MenuName, amountOption);
             }
 
             _settingsListNodes.Add(Settings.CurrencyStashTab);
@@ -503,7 +444,7 @@ namespace Stashie
                     var ignoredWidth = Settings.IgnoredCells.GetLength(1);
 
                     if (ignoredHeight != 5 || ignoredWidth != 12)
-                        LogError("Stashie: Wrong IgnoredCells size! Should be 12x5. Reseting to default..", 5);
+                        LogError("Stashie: Wrong IgnoredCells size! Should be 12x5. Resetting to default..", 5);
                     else
                         return;
                 }
@@ -511,7 +452,7 @@ namespace Stashie
                 {
                     LogError(
                         "Stashie: Can't decode IgnoredCells settings in " + fileName +
-                        ". Reseting to default. Error: " + ex.Message,
+                        ". Resetting to default. Error: " + ex.Message,
                         5);
                 }
             }
@@ -525,67 +466,58 @@ namespace Stashie
 
         public override void Render()
         {
-            TestAction?.Invoke();
-
-            if (CoroutineWorker != null && CoroutineWorker.IsDone)
+            if (_coroutineWorker != null && _coroutineWorker.IsDone)
             {
                 Input.KeyUp(Keys.LControlKey);
-                CoroutineWorker = null;
+                _coroutineWorker = null;
             }
 
             var uiTabsOpened = GameController.Game.IngameState.IngameUi.InventoryPanel.IsVisible &&
                                GameController.Game.IngameState.IngameUi.StashElement.IsVisibleLocal;
 
-            if (!uiTabsOpened && CoroutineWorker != null && !CoroutineWorker.IsDone)
+            if (!uiTabsOpened && _coroutineWorker != null && !_coroutineWorker.IsDone)
             {
                 Input.KeyUp(Keys.LControlKey);
-                CoroutineWorker = Core.ParallelRunner.FindByName(coroutineName);
-                CoroutineWorker?.Done();
-                LogError($"When stashie working, stash UI was  closed, error happens in tab #{visibleStashIndex}", 5);
+                _coroutineWorker = Core.ParallelRunner.FindByName(CoroutineName);
+                _coroutineWorker?.Done();
+                LogError($"When stashie working, stash UI was  closed, error happens in tab #{_visibleStashIndex}", 5);
             }
 
-            if (CoroutineWorker != null && CoroutineWorker.Running && DebugTimer.ElapsedMilliseconds > 15000)
+            if (_coroutineWorker != null && _coroutineWorker.Running && _debugTimer.ElapsedMilliseconds > 15000)
             {
                 LogError(
-                    $"Stopped because work more than 15 sec. Error in {GetIndexOfCurrentVisibleTab()} type {GetTypeOfCurrentVisibleStash()} visibleStashIndex: {visibleStashIndex}",
+                    $"Stopped because work more than 15 sec. Error in {GetIndexOfCurrentVisibleTab()} type {GetTypeOfCurrentVisibleStash()} visibleStashIndex: {_visibleStashIndex}",
                     5);
 
-                CoroutineWorker?.Done();
-                DebugTimer.Restart();
-                DebugTimer.Stop();
+                _coroutineWorker?.Done();
+                _debugTimer.Restart();
+                _debugTimer.Stop();
                 Input.KeyUp(Keys.LControlKey);
             }
 
-            if (Settings.DropHotkey.PressedOnce())
-            {
-                if (uiTabsOpened)
-                {
-                    CoroutineWorker = new Coroutine(ProcessInventoryItems(), this, coroutineName);
-                    Core.ParallelRunner.Run(CoroutineWorker);
-                }
-            }
+            if (!Settings.DropHotkey.PressedOnce()) return;
+            if (!uiTabsOpened) return;
+            _coroutineWorker = new Coroutine(ProcessInventoryItems(), this, CoroutineName);
+            Core.ParallelRunner.Run(_coroutineWorker);
         }
 
         private IEnumerator ProcessInventoryItems()
         {
-            DebugTimer.Restart();
+            _debugTimer.Restart();
             yield return ParseItems();
 
             var cursorPosPreMoving = Input.ForceMousePosition;
-            if (_dropItems.Count > 0)
-            {
-                yield return DropToStash();
-            }
+            if (_dropItems.Count > 0) yield return DropToStash();
 
             yield return ProcessRefills();
             yield return Input.SetCursorPositionSmooth(new Vector2(cursorPosPreMoving.X, cursorPosPreMoving.Y));
             Input.MouseMove();
 
-            CoroutineWorker = Core.ParallelRunner.FindByName(coroutineName);
-            CoroutineWorker?.Done();
+            _coroutineWorker = Core.ParallelRunner.FindByName(CoroutineName);
+            _coroutineWorker?.Done();
 
-            DebugTimer.Restart();
-            DebugTimer.Stop();
+            _debugTimer.Restart();
+            _debugTimer.Stop();
         }
 
         private IEnumerator ParseItems()
@@ -614,10 +546,7 @@ namespace Stashie
                     var testItem = new ItemData(invItem, baseItemType);
                     var result = CheckFilters(testItem);
                     if (result != null)
-                    {
                         _dropItems.Add(result);
-                        //WriteInventoryNames();
-                    }
                 }
             }
         }
@@ -625,12 +554,12 @@ namespace Stashie
         private void WriteInventoryNames()
         {
             var path = $"{DirectoryFullName}\\InventoryDebugList.txt";
-            StringBuilder sb = new StringBuilder();
-            foreach (var inventoryitem in _dropItems)
+            var sb = new StringBuilder();
+            foreach (var inventoryItem in _dropItems)
             {
-                sb.AppendLine(inventoryitem.ItemData.BaseName);
-                sb.AppendLine(inventoryitem.ItemData.ClassName);
-                sb.AppendLine(inventoryitem.ItemData.Path.ToString());
+                sb.AppendLine(inventoryItem.ItemData.BaseName);
+                sb.AppendLine(inventoryItem.ItemData.ClassName);
+                sb.AppendLine(inventoryItem.ItemData.Path.ToString());
             }
 
             File.WriteAllText(path, sb.ToString());
@@ -655,7 +584,6 @@ namespace Stashie
         private FilterResult CheckFilters(ItemData itemData)
         {
             foreach (var filter in _customFilters)
-            {
                 try
                 {
                     if (!filter.AllowProcess) continue;
@@ -666,14 +594,13 @@ namespace Stashie
                 {
                     DebugWindow.LogError($"Check filters error: {ex}");
                 }
-            }
 
             return null;
         }
 
         private IEnumerator DropToStash()
         {
-            coroutineIteration++;
+            _coroutineIteration++;
 
             yield return DropItemsToStash();
         }
@@ -681,16 +608,15 @@ namespace Stashie
         private IEnumerator DropItemsToStash()
         {
             var tries = 0;
-            var index = 0;
             NormalInventoryItem lastHoverItem = null;
             PublishEvent("stashie_start_drop_items", null);
 
             while (_dropItems.Count > 0 && tries < 2)
             {
                 tries++;
-                visibleStashIndex = -1;
-                visibleStashIndex = GetIndexOfCurrentVisibleTab();
-                var sortedByStash = _dropItems.OrderByDescending(x => x.StashIndex == visibleStashIndex)
+                _visibleStashIndex = -1;
+                _visibleStashIndex = GetIndexOfCurrentVisibleTab();
+                var sortedByStash = _dropItems.OrderByDescending(x => x.StashIndex == _visibleStashIndex)
                     .ThenBy(x => x.StashIndex).ToList();
                 var ingameStateCurLatency = GameController.Game.IngameState.CurLatency;
                 var latency = (int) ingameStateCurLatency + Settings.ExtraDelay;
@@ -702,13 +628,13 @@ namespace Stashie
 
                 foreach (var stashResults in sortedByStash)
                 {
-                    coroutineIteration++;
-                    CoroutineWorker?.UpdateTicks(coroutineIteration);
-                    var tryTime = DebugTimer.ElapsedMilliseconds + 2000 + latency;
+                    _coroutineIteration++;
+                    _coroutineWorker?.UpdateTicks(_coroutineIteration);
+                    var tryTime = _debugTimer.ElapsedMilliseconds + 2000 + latency;
 
-                    if (stashResults.StashIndex != visibleStashIndex)
+                    if (stashResults.StashIndex != _visibleStashIndex)
                     {
-                        StackItemTimer.Restart();
+                        _stackItemTimer.Restart();
                         var waited = waitedItems.Count > 0;
 
                         while (waited)
@@ -723,17 +649,14 @@ namespace Stashie
                             {
                                 var contains = visibleInventoryItems.Contains(waitedItem.ItemData.InventoryItem);
 
-                                if (contains)
-                                {
-                                    Input.SetCursorPos(waitedItem.ClickPos + _clickWindowOffset);
-                                    yield return wait3ms;
+                                if (!contains) continue;
+                                Input.SetCursorPos(waitedItem.ClickPos + _clickWindowOffset);
+                                yield return _wait3Ms;
 
-                                    //   yield return Input.LeftClick();
-                                    Input.Click(MouseButtons.Left);
-                                    yield return wait10ms;
-                                    Input.MouseMove();
-                                    waited = true;
-                                }
+                                Input.Click(MouseButtons.Left);
+                                yield return _wait10Ms;
+                                Input.MouseMove();
+                                waited = true;
                             }
 
                             yield return new WaitTime(100);
@@ -742,7 +665,7 @@ namespace Stashie
 
                             if (!waited) waitedItems.Clear();
 
-                            if (DebugTimer.ElapsedMilliseconds > tryTime)
+                            if (_debugTimer.ElapsedMilliseconds > tryTime)
                             {
                                 LogMessage($"Error while waiting items {waitedItems.Count}");
                                 yield break;
@@ -750,7 +673,7 @@ namespace Stashie
 
                             yield return dropItemsToStashWaitTime;
 
-                            if (StackItemTimer.ElapsedMilliseconds > 1000 + latency)
+                            if (_stackItemTimer.ElapsedMilliseconds > 1000 + latency)
                                 break;
                         }
 
@@ -758,76 +681,55 @@ namespace Stashie
                     }
 
                     var visibleInventory =
-                        GameController.IngameState.IngameUi.StashElement.AllInventories[visibleStashIndex];
+                        GameController.IngameState.IngameUi.StashElement.AllInventories[_visibleStashIndex];
 
                     while (visibleInventory == null)
                     {
                         visibleInventory =
-                            GameController.IngameState.IngameUi.StashElement.AllInventories[visibleStashIndex];
-                        yield return wait10ms;
+                            GameController.IngameState.IngameUi.StashElement.AllInventories[_visibleStashIndex];
+                        yield return _wait10Ms;
 
-                        if (DebugTimer.ElapsedMilliseconds > tryTime + 2000)
-                        {
-                            LogMessage($"Error while loading tab, Index: {visibleStashIndex}");
-                            yield break;
-                        }
+                        if (_debugTimer.ElapsedMilliseconds <= tryTime + 2000) continue;
+                        LogMessage($"Error while loading tab, Index: {_visibleStashIndex}");
+                        yield break;
                     }
 
                     while (GetTypeOfCurrentVisibleStash() == InventoryType.InvalidInventory)
                     {
                         yield return dropItemsToStashWaitTime;
 
-                        if (DebugTimer.ElapsedMilliseconds > tryTime)
-                        {
-                            LogMessage($"Error with inventory type, Index: {visibleStashIndex}");
-                            yield break;
-                        }
+                        if (_debugTimer.ElapsedMilliseconds <= tryTime) continue;
+                        LogMessage($"Error with inventory type, Index: {_visibleStashIndex}");
+                        yield break;
                     }
 
                     var inventory = GameController.IngameState.IngameUi.InventoryPanel[InventoryIndex.PlayerInventory];
                     Input.SetCursorPos(stashResults.ClickPos + _clickWindowOffset);
 
-                    /*while (!inventory.CursorHoverInventory)
-                    {
-                      Input.SetCursorPos(stashResults.ClickPos + _clickWindowOffset);
-                      yield return wait10ms;
-                      if (DebugTimer.ElapsedMilliseconds > tryTime)
-                      {
-                          LogMessage($"Error while try set cursor in inventory, Index: {visibleStashIndex}", 1);
-                          yield break;
-                      }
-                    }*/
-                    //yield return Input.LeftClick();
                     while (inventory.HoverItem == null)
                     {
                         Input.SetCursorPos(stashResults.ClickPos + _clickWindowOffset);
-                        yield return wait3ms;
+                        yield return _wait3Ms;
 
-                        if (DebugTimer.ElapsedMilliseconds > tryTime)
-                        {
-                            LogMessage($"Error while wait hover item null, Index: {visibleStashIndex}");
-                            yield break;
-                        }
+                        if (_debugTimer.ElapsedMilliseconds <= tryTime) continue;
+                        LogMessage($"Error while wait hover item null, Index: {_visibleStashIndex}");
+                        yield break;
                     }
 
                     if (lastHoverItem != null)
-                    {
                         while (inventory.HoverItem == null || inventory.HoverItem.Address == lastHoverItem.Address)
                         {
                             Input.SetCursorPos(stashResults.ClickPos + _clickWindowOffset);
-                            yield return wait3ms;
+                            yield return _wait3Ms;
 
-                            if (DebugTimer.ElapsedMilliseconds > tryTime)
-                            {
-                                LogMessage($"Error while wait hover item, Index: {visibleStashIndex}");
-                                yield break;
-                            }
+                            if (_debugTimer.ElapsedMilliseconds <= tryTime) continue;
+                            LogMessage($"Error while wait hover item, Index: {_visibleStashIndex}");
+                            yield break;
                         }
-                    }
 
                     lastHoverItem = inventory.HoverItem;
                     Input.Click(MouseButtons.Left);
-                    yield return wait10ms;
+                    yield return _wait10Ms;
                     yield return dropItemsToStashWaitTime;
                     var typeOfCurrentVisibleStash = GetTypeOfCurrentVisibleStash();
 
@@ -835,7 +737,7 @@ namespace Stashie
                         typeOfCurrentVisibleStash == InventoryType.DivinationStash)
                         waitedItems.Add(stashResults);
 
-                    DebugTimer.Restart();
+                    _debugTimer.Restart();
 
                     PublishEvent("stashie_finish_drop_items_to_stash_tab", null);
                 }
@@ -888,19 +790,16 @@ namespace Stashie
 
                     for (var x = iPosX; x <= iPosX + iBase.ItemCellsSizeX - 1; x++)
                     for (var y = iPosY; y <= iPosY + iBase.ItemCellsSizeY - 1; y++)
-                    {
                         if (x >= 0 && x <= 11 && y >= 0 && y <= 4)
                             filledCells[y, x] = 1;
                         else
                             LogMessage($"Out of range: {x} {y}", 10);
-                    }
                 }
 
                 if (!item.HasComponent<ExileCore.PoEMemory.Components.Stack>()) continue;
 
                 foreach (var refill in _customRefills)
                 {
-                    //if (refill.AmountOption.Value == 0) continue;
                     var bit = GameController.Files.BaseItemTypes.Translate(item.Path);
                     if (bit.BaseName != refill.CurrencyClass) continue;
 
@@ -911,7 +810,7 @@ namespace Stashie
                     if (refill.OwnedCount < 0 || refill.OwnedCount > 40)
                     {
                         LogError(
-                            $"Ignoring refill: {refill.CurrencyClass}: Stacksize {refill.OwnedCount} not in range 0-40 ",
+                            $"Ignoring refill: {refill.CurrencyClass}: Stack size {refill.OwnedCount} not in range 0-40 ",
                             5);
                         refill.OwnedCount = -1;
                     }
@@ -926,7 +825,6 @@ namespace Stashie
             var freeCelPos = new Point();
 
             if (!Settings.AllowHaveMore.Value)
-            {
                 for (var x = 0; x <= 11; x++)
                 {
                     for (var y = 0; y <= 4; y++)
@@ -940,19 +838,12 @@ namespace Stashie
 
                     if (freeCellFound) break;
                 }
-            }
 
             foreach (var refill in _customRefills)
             {
-                if (refill.OwnedCount == -1)
-                {
-                    continue;
-                }
+                if (refill.OwnedCount == -1) continue;
 
-                if (refill.OwnedCount == refill.AmountOption.Value)
-                {
-                    continue;
-                }
+                if (refill.OwnedCount == refill.AmountOption.Value) continue;
 
                 if (refill.OwnedCount < refill.AmountOption.Value)
 
@@ -961,8 +852,10 @@ namespace Stashie
                 {
                     if (!currencyTabVisible)
                     {
-                        if (Settings.CurrencyStashTab.Index != visibleStashIndex)
+                        if (Settings.CurrencyStashTab.Index != _visibleStashIndex)
+                        {
                             yield return SwitchToTab(Settings.CurrencyStashTab.Index);
+                        }
                         else
                         {
                             currencyTabVisible = true;
@@ -971,10 +864,10 @@ namespace Stashie
                     }
 
                     var moveCount = refill.AmountOption.Value - refill.OwnedCount;
-                    var currStashItems = GameController.Game.IngameState.IngameUi.StashElement.VisibleStash
+                    var currentStashItems = GameController.Game.IngameState.IngameUi.StashElement.VisibleStash
                         .VisibleInventoryItems;
 
-                    var foundSourceOfRefill = currStashItems
+                    var foundSourceOfRefill = currentStashItems
                         .Where(x => GameController.Files.BaseItemTypes.Translate(x.Item.Path).BaseName ==
                                     refill.CurrencyClass).ToList();
 
@@ -995,7 +888,7 @@ namespace Stashie
                             {
                                 moveCount--;
                                 LogMessage(
-                                    $"Inventoy ({refill.InventPos.X}, {refill.InventPos.Y}) is occupied by the wrong item!",
+                                    $"Inventory ({refill.InventPos.X}, {refill.InventPos.Y}) is occupied by the wrong item!",
                                     5);
                                 continue;
                             }
@@ -1026,7 +919,7 @@ namespace Stashie
 
                     if (!currencyTabVisible)
                     {
-                        if (Settings.CurrencyStashTab.Index != visibleStashIndex)
+                        if (Settings.CurrencyStashTab.Index != _visibleStashIndex)
                         {
                             yield return SwitchToTab(Settings.CurrencyStashTab.Index);
                             continue;
@@ -1044,7 +937,6 @@ namespace Stashie
                     yield return new WaitTime(delay);
                     Input.KeyDown(Keys.LControlKey);
 
-                    //  yield return Mouse.SetCursorPosAndLeftClickHuman(destination + _clickWindowOffset,Settings.ExtraDelay.Value);
                     yield return Input.SetCursorPositionSmooth(destination + _clickWindowOffset);
                     yield return new WaitTime(Settings.ExtraDelay);
                     Input.Click(MouseButtons.Left);
@@ -1057,7 +949,8 @@ namespace Stashie
             }
         }
 
-        private Vector2 GetInventoryClickPosByCellIndex(Inventory inventory, int indexX, int indexY, float cellSize)
+        private static Vector2 GetInventoryClickPosByCellIndex(Inventory inventory, int indexX, int indexY,
+            float cellSize)
         {
             return inventory.InventoryUIElement.GetClientRect().TopLeft +
                    new Vector2(cellSize * (indexX + 0.5f), cellSize * (indexY + 0.5f));
@@ -1068,19 +961,15 @@ namespace Stashie
             var delay = (int) GameController.Game.IngameState.CurLatency * 2 + Settings.ExtraDelay;
             Input.KeyDown(Keys.ShiftKey);
 
-            while (!Input.IsKeyDown(Keys.ShiftKey))
-            {
-                yield return new WaitTime(WHILE_DELAY);
-            }
+            while (!Input.IsKeyDown(Keys.ShiftKey)) yield return new WaitTime(WhileDelay);
 
-            // yield return Mouse.SetCursorPosAndLeftClickHuman(from + _clickWindowOffset, Settings.ExtraDelay.Value);
             yield return Input.SetCursorPositionSmooth(from + _clickWindowOffset);
             yield return new WaitTime(Settings.ExtraDelay);
             Input.Click(MouseButtons.Left);
             Input.MouseMove();
-            yield return new WaitTime(INPUT_DELAY);
+            yield return new WaitTime(InputDelay);
             Input.KeyUp(Keys.ShiftKey);
-            yield return new WaitTime(INPUT_DELAY + 50);
+            yield return new WaitTime(InputDelay + 50);
 
             if (amount > 40)
             {
@@ -1104,14 +993,13 @@ namespace Stashie
 
             yield return new WaitTime(delay);
             yield return Input.KeyPress(Keys.Enter);
-            yield return new WaitTime(delay + INPUT_DELAY);
+            yield return new WaitTime(delay + InputDelay);
 
-            //  yield return Mouse.SetCursorPosAndLeftClickHuman(to + _clickWindowOffset, Settings.ExtraDelay.Value);
             yield return Input.SetCursorPositionSmooth(to + _clickWindowOffset);
             yield return new WaitTime(Settings.ExtraDelay);
             Input.Click(MouseButtons.Left);
 
-            yield return new WaitTime(delay + INPUT_DELAY);
+            yield return new WaitTime(delay + InputDelay);
         }
 
         #endregion
@@ -1125,12 +1013,9 @@ namespace Stashie
             // We don't want to Switch to a tab that we are already on
             //var stashPanel = GameController.Game.IngameState.IngameUi.StashElement;
 
-            visibleStashIndex = GetIndexOfCurrentVisibleTab();
-            var travelDistance = Math.Abs(tabIndex - visibleStashIndex);
-            if (travelDistance == 0)
-            {
-                yield break;
-            }
+            _visibleStashIndex = GetIndexOfCurrentVisibleTab();
+            var travelDistance = Math.Abs(tabIndex - _visibleStashIndex);
+            if (travelDistance == 0) yield break;
 
             // We want to maximum wait 20 times the Current Latency before giving up in our while loops.
             //var maxNumberOfTries = latency * 20 > 2000 ? latency * 20 / WHILE_DELAY : 2000 / WHILE_DELAY;
@@ -1145,7 +1030,7 @@ namespace Stashie
                 yield return new WaitTime(latency + Settings.ExtraDelay);
             }
 
-            visibleStashIndex = GetIndexOfCurrentVisibleTab();
+            _visibleStashIndex = GetIndexOfCurrentVisibleTab();
         }
 
         private IEnumerator SwitchToTabViaArrowKeys(int tabIndex)
@@ -1180,23 +1065,17 @@ namespace Stashie
 
             var dropdownMenu = GameController.Game.IngameState.IngameUi.StashElement.ViewAllStashPanel;
             var allTabsButton = viewAllTabsButton.GetClientRect();
-            var slider = stashcount > MAXSHOWN_SIDEBARSTASHTABS;
+            var slider = _stashCount > MaxShownSidebarStashTabs;
             if (!dropdownMenu.IsVisible)
             {
                 Input.SetCursorPos(allTabsButton.Center);
-                yield return wait3ms;
+                yield return _wait3Ms;
                 Input.MouseMove();
                 Input.LeftDown();
-                yield return wait1ms;
+                yield return _wait1Ms;
                 Input.LeftUp();
-                yield return wait10ms;
+                yield return _wait10Ms;
                 //wait for the dropdown menu to become visible
-                /*
-                for (var tries = 0; !dropdownMenu.IsVisible && tries < 20 ; ++tries)
-                {
-                    yield return new WaitTime(latency);
-                }
-                */
                 if (!dropdownMenu.IsVisible)
                 {
                     LogError($"Error in opening DropdownMenu.", 5);
@@ -1204,61 +1083,47 @@ namespace Stashie
                 }
             }
 
-            RectangleF tabPos;
             // Make sure that we are scrolled to the top in the menu.
             if (slider)
-            {
-                for (int i = 0; i < stashcount - MAXSHOWN_SIDEBARSTASHTABS + 1; ++i)
+                for (var i = 0; i < _stashCount - MaxShownSidebarStashTabs + 1; ++i)
                 {
                     Input.KeyDown(Keys.Up);
-                    yield return wait1ms;
+                    yield return _wait1Ms;
                     Input.KeyUp(Keys.Up);
-                    yield return wait1ms;
+                    yield return _wait1Ms;
                 }
-            }
 
-            //get clickposition of tab label
-            for (int i = 0; i < tabIndex; ++i)
+            //get click position of tab label
+            for (var i = 0; i < tabIndex; ++i)
             {
                 Input.KeyDown(Keys.Down);
-                yield return wait1ms;
+                yield return _wait1Ms;
                 Input.KeyUp(Keys.Down);
-                yield return wait1ms;
+                yield return _wait1Ms;
             }
-            //tabPos = dropdownMenu.GetChildAtIndex(1).GetChildAtIndex(MAXSHOWN_SIDEBARSTASHTABS - 1).GetClientRect();
 
             //enter-key Method
             Input.KeyDown(Keys.Enter);
-            yield return wait1ms;
+            yield return _wait1Ms;
             Input.KeyUp(Keys.Enter);
-            yield return wait1ms;
-            /*
-            Input.SetCursorPos(tabPos.Center);
-            yield return wait10ms;
-            Input.MouseMove();
-            Input.LeftDown();
-            yield return new WaitTime(1);
-            Input.LeftUp();
-            yield return new WaitTime(1);
-            */
-            //reset Sliderposition
-            if (slider)
+            yield return _wait1Ms;
+
+            //reset Slider position
+            if (!slider) yield break;
             {
                 if (!dropdownMenu.IsVisible)
                 {
                     //opening DropdownMenu
                     Input.SetCursorPos(allTabsButton.Center);
-                    yield return wait10ms;
+                    yield return _wait10Ms;
                     Input.MouseMove();
                     Input.LeftDown();
-                    yield return wait1ms;
+                    yield return _wait1Ms;
                     Input.LeftUp();
-                    yield return wait10ms;
+                    yield return _wait10Ms;
                     // wait for the dropdown menu to become visible.
-                    for (int count = 0; !dropdownMenu.IsVisible && count <= 20; ++count)
-                    {
+                    for (var count = 0; !dropdownMenu.IsVisible && count <= 20; ++count)
                         yield return new WaitTime(latency);
-                    }
 
                     if (!dropdownMenu.IsVisible)
                     {
@@ -1268,7 +1133,7 @@ namespace Stashie
                 }
 
                 //"scrolling" back up
-                for (int i = 0; i < stashcount - MAXSHOWN_SIDEBARSTASHTABS + 1; ++i)
+                for (var i = 0; i < _stashCount - MaxShownSidebarStashTabs + 1; ++i)
                 {
                     Input.KeyDown(Keys.Up);
                     yield return new WaitTime(1);
@@ -1286,9 +1151,7 @@ namespace Stashie
         private InventoryType GetTypeOfCurrentVisibleStash()
         {
             var stashPanelVisibleStash = GameController.Game.IngameState.IngameUi?.StashElement?.VisibleStash;
-            if (stashPanelVisibleStash != null) return stashPanelVisibleStash.InvType;
-
-            return InventoryType.InvalidInventory;
+            return stashPanelVisibleStash?.InvType ?? InventoryType.InvalidInventory;
         }
 
         #endregion
@@ -1310,7 +1173,6 @@ namespace Stashie
             _settingsListNodes = new List<ListIndexNode>(100);
             LoadCustomRefills();
             LoadCustomFilters();
-            // LoadIgnoredCells();
 
             try
             {
@@ -1318,11 +1180,6 @@ namespace Stashie
                     (int) GameController.Game.IngameState.IngameUi.StashElement.TotalStashes - 1;
                 var names = GameController.Game.IngameState.IngameUi.StashElement.AllStashNames;
                 UpdateStashNames(names);
-                /*     foreach (var lOption in _settingsListNodes)
-                     {
-                         var option = lOption; //Enumerator delegate fix
-                         option.OnValueSelected += delegate(string newValue) { OnSettingsStashNameChanged(option, newValue); };
-                     }*/
             }
             catch (Exception e)
             {
@@ -1340,7 +1197,7 @@ namespace Stashie
 
         private List<string> _renamedAllStashNames;
 
-        private void UpdateStashNames(IList<string> newNames)
+        private void UpdateStashNames(ICollection<string> newNames)
         {
             Settings.AllStashNames = newNames.ToList();
 
@@ -1371,7 +1228,6 @@ namespace Stashie
             Settings.AllStashNames.Insert(0, "Ignore");
 
             foreach (var lOption in _settingsListNodes)
-            {
                 try
                 {
                     lOption.SetListValues(_renamedAllStashNames);
@@ -1391,11 +1247,15 @@ namespace Stashie
                                 lOption.Value = _renamedAllStashNames[0];
                             }
                             else
+                            {
                                 lOption.Value = _renamedAllStashNames[lOption.Index + 1]; //    Just update it's name
+                            }
                         }
                         else
+                        {
                             lOption.Value =
                                 _renamedAllStashNames[0]; //Actually it was "Ignore", we just update it (can be removed)
+                        }
                     }
                     else //tab just change it's index
                     {
@@ -1413,33 +1273,26 @@ namespace Stashie
                 {
                     DebugWindow.LogError($"UpdateStashNames _settingsListNodes {e}");
                 }
-            }
 
             GenerateMenu();
         }
 
-        private static readonly WaitTime wait2sec = new WaitTime(2000);
-        private static readonly WaitTime wait1sec = new WaitTime(1000);
-        private uint counterStashTabNamesCoroutine;
+        private static readonly WaitTime Wait2Sec = new WaitTime(2000);
+        private static readonly WaitTime Wait1Sec = new WaitTime(1000);
+        private uint _counterStashTabNamesCoroutine;
 
         public IEnumerator StashTabNamesUpdater_Thread()
         {
             while (true)
             {
-                while (!GameController.Game.IngameState.InGame)
-                {
-                    yield return wait2sec;
-                }
+                while (!GameController.Game.IngameState.InGame) yield return Wait2Sec;
 
                 var stashPanel = GameController.Game.IngameState?.IngameUi?.StashElement;
 
-                while (stashPanel == null || !stashPanel.IsVisibleLocal)
-                {
-                    yield return wait1sec;
-                }
+                while (stashPanel == null || !stashPanel.IsVisibleLocal) yield return Wait1Sec;
 
-                counterStashTabNamesCoroutine++;
-                StashTabNamesCoroutine?.UpdateTicks(counterStashTabNamesCoroutine);
+                _counterStashTabNamesCoroutine++;
+                _stashTabNamesCoroutine?.UpdateTicks(_counterStashTabNamesCoroutine);
                 var cachedNames = Settings.AllStashNames;
                 var realNames = stashPanel.AllStashNames;
 
@@ -1458,7 +1311,7 @@ namespace Stashie
                     break;
                 }
 
-                yield return wait1sec;
+                yield return Wait1Sec;
             }
         }
 

--- a/Stashie.csproj
+++ b/Stashie.csproj
@@ -85,8 +85,6 @@
   <ItemGroup>
     <Content Include=".gitignore" />
     <Content Include="GitUpdateConfig.txt" />
-    <Content Include="Stashie.dll" />
-    <Content Include="Stashie.pdb" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FilterParameterCompare.cs" />


### PR DESCRIPTION
**Reason**
When editing your FiltersConfig.txt file it's annoying that you have to restart PoeHelper in order for the changes to take effect.

**Solution**
Adds a "Reload config" button to the settings window.
![image](https://user-images.githubusercontent.com/7005867/95364714-7770cb80-08d1-11eb-842c-c2f3868b788b.png)

When the button is pressed the config is parsed again and loaded into the currently active filter config.

**Future ideas**
We should provide the option to have multiple configuration files.